### PR TITLE
Feature: Hide input on shoutbox for guests if they may not participate in the chat

### DIFF
--- a/chat/css/shoutbox.css
+++ b/chat/css/shoutbox.css
@@ -45,6 +45,9 @@
 #ajaxChatContent #ajaxChatCopyright {
 	margin-top:5px;
 }
+#ajaxChatContent #ajaxChatInputFieldContainer.write_forbidden {
+	display:none;
+}
 
 
 /*

--- a/chat/lib/class/AJAXChatTemplate.php
+++ b/chat/lib/class/AJAXChatTemplate.php
@@ -165,6 +165,13 @@ class AJAXChatTemplate {
 				return $this->getLogsDayOptionTags();
 			case 'LOGS_HOUR_OPTIONS':
 				return $this->getLogsHourOptionTags();
+			case 'CLASS_WRITEABLE':
+				$userdata = $this->ajaxChat->getValidLoginUserData();
+				$guestwrite = $this->ajaxChat->getConfig('allowGuestWrite');
+				if ($userdata['userRole'] === AJAX_CHAT_GUEST && $guestwrite === false)
+					return 'write_forbidden';
+				else
+					return 'write_allowed';
 			
 			default:
 				return $this->ajaxChat->replaceCustomTemplateTags($tag, $tagContent);

--- a/chat/lib/template/shoutbox.html
+++ b/chat/lib/template/shoutbox.html
@@ -6,7 +6,7 @@
 	<script src="[AJAX_CHAT_URL/]js/config.js" type="text/javascript" charset="UTF-8"></script>
 	<script src="[AJAX_CHAT_URL/]js/FABridge.js" type="text/javascript" charset="UTF-8"></script>
 	<div id="ajaxChatChatList"></div>
-	<div id="ajaxChatInputFieldContainer">
+	<div id="ajaxChatInputFieldContainer" class="[CLASS_WRITEABLE/]">
 		<input id="ajaxChatInputField" type="text" maxlength="[MESSAGE_TEXT_MAX_LENGTH/]" onkeypress="ajaxChat.handleInputFieldKeyPress(event);"/>
 	</div>
 	<script type="text/javascript">


### PR DESCRIPTION
Please add this really useful (in terms of usability) feature.
Also see https://sourceforge.net/p/ajax-chat/patches/11/

This would have to be merged with the various branches but as I'm not sure how you prefer your pull requests this is against master only.
