### PR TITLE
Add slowdown to reduce ajax rate…

### DIFF
--- a/chat/css/global.css
+++ b/chat/css/global.css
@@ -67,6 +67,9 @@
 	bottom:150px;
 	overflow:auto;
 }
+#content.logs #chatList {
+	right:20px;
+}
 #content #inputFieldContainer {
 	position:absolute;
 	left:20px;
@@ -259,7 +262,7 @@
 #content img {
 	border:none;
 }
-#content #chatList, #content #onlineListContainer, #content #helpContainer, #content #settingsContainer, #content #colorCodesContainer, 
+#content #chatList, #content #onlineListContainer, #content #helpContainer, #content #settingsContainer, #content #colorCodesContainer,
 #content #colorCodesContainer a, #content textarea {
 	border-width:1px;
 	border-style:solid;

--- a/chat/js/chat.js
+++ b/chat/js/chat.js
@@ -4,10 +4,10 @@
  * @copyright (c) Sebastian Tschan
  * @license Modified MIT License
  * @link https://blueimp.net/ajax/
- * 
+ *
  * The SELFHTML documentation has been used throughout this project:
  * http://selfhtml.org
- * 
+ *
  * Stylesheet and cookie methods have been inspired by Paul Sowden (A List Apart):
  * http://www.alistapart.com/stories/alternate/
  */
@@ -89,17 +89,18 @@ var ajaxChat = {
 	DOMbuffering: null,
 	DOMbuffer: null,
 	DOMbufferRowClass: 'rowOdd',
-	
-	init: function(config, lang, initSettings, initStyle, initialize, initializeFunction, finalizeFunction) {	
+	debug: false,
+
+	init: function(config, lang, initSettings, initStyle, initialize, initializeFunction, finalizeFunction) {
 		this.httpRequest		= {};
 		this.usersList			= [];
 		this.userNamesList		= [];
 		this.userMenuCounter	= 0;
 		this.lastID				= 0;
 		this.localID			= 0;
-		this.lang				= lang;		
+		this.lang				= lang;
 		this.initConfig(config);
-		this.initDirectories();		
+		this.initDirectories();
 		if(initSettings) {
 			this.initSettings();
 		}
@@ -112,7 +113,7 @@ var ajaxChat = {
 			this.setLoadHandler();
 		}
 	},
-	
+
 	initConfig: function(config) {
 		this.loginChannelID			= config['loginChannelID'];
 		this.loginChannelName		= config['loginChannelName'];
@@ -137,7 +138,7 @@ var ajaxChat = {
 		this.chatBotName			= config['chatBotName'];
 		this.chatBotID				= config['chatBotID'];
 		this.allowUserMessageDelete	= config['allowUserMessageDelete'];
-		this.inactiveTimeout		= config['inactiveTimeout'];
+		this.inactiveTimeout		= Math.max(config['inactiveTimeout'],2);
 		this.privateChannelDiff		= config['privateChannelDiff'];
 		this.privateMessageDiff		= config['privateMessageDiff'];
 		this.showChannelMessages	= config['showChannelMessages'];
@@ -146,6 +147,7 @@ var ajaxChat = {
 		this.socketServerHost		= config['socketServerHost'];
 		this.socketServerPort		= config['socketServerPort'];
 		this.socketServerChatID		= config['socketServerChatID'];
+		this.debug					= config['debug'];
 		this.DOMbuffering			= false;
 		this.DOMbuffer				= "";
 		this.retryTimerDelay 		= (this.inactiveTimeout*6000 - this.timerRate)/4 + this.timerRate;
@@ -157,7 +159,7 @@ var ajaxChat = {
 		this.dirs['sounds']		= this.baseURL+'sounds/';
 		this.dirs['flash']		= this.baseURL+'flash/';
 	},
-	
+
 	initSettings: function() {
 		var cookie = this.readCookie(this.sessionName + '_settings'),
 			i, settingsArray, setting, key, value, number;
@@ -209,21 +211,21 @@ var ajaxChat = {
 				if(this.inArray(this.nonPersistentSettings, property)) {
 					if(this.unusedSettings && this.unusedSettings[property]) {
 						// Store the unusedSetting previously stored:
-						this.settings[property] = this.unusedSettings[property];	
+						this.settings[property] = this.unusedSettings[property];
 					} else {
 						continue;
 					}
 				}
 				settingsArray.push(property + '=' + this.encodeText(this.settings[property]));
 			}
-			this.createCookie(this.sessionName + '_settings', settingsArray.join('&'), this.cookieExpiration);	
+			this.createCookie(this.sessionName + '_settings', settingsArray.join('&'), this.cookieExpiration);
 		}
 	},
-	
+
 	getSettings: function() {
 		return this.settings;
 	},
-	
+
 	getSetting: function(key) {
 		// Only return null if setting is null or undefined, not if it is false:
 		for(var property in this.settings) {
@@ -233,11 +235,11 @@ var ajaxChat = {
 		}
 		return null;
 	},
-	
+
 	setSetting: function(key, value) {
 		this.settings[key] = value;
 	},
-	
+
 	initializeSettings: function() {
 		if(this.settings['persistFontColor'] && this.settings['fontColor']) {
 			// Set the inputField font color to the font color:
@@ -246,17 +248,17 @@ var ajaxChat = {
 			}
 		}
 	},
-	
-	initialize: function() {	
+
+	initialize: function() {
 		this.setUnloadHandler();
 		this.initializeDocumentNodes();
 		this.loadPageAttributes();
 		this.initEmoticons();
 		this.initColorCodes();
-		this.initializeSettings();		
+		this.initializeSettings();
 		this.setSelectedStyle();
 		this.customInitialize();
-		//preload the Alert icon (it can't display if there's no connection unless it's cached!)
+		// preload the Alert icon (it can't display if there's no connection unless it's cached!)
 		this.setStatus('retrying');
 		if(typeof this.initializeFunction === 'function') {
 			this.initializeFunction();
@@ -283,17 +285,17 @@ var ajaxChat = {
 		}
 		this.updateChat(params);
 	},
-	
+
 	setStartChatHandler: function() {
 		if(this.dom['inputField']) {
 			this.dom['inputField'].onfocus = function() {
 				ajaxChat.startChat();
 				// Reset the onfocus event on first call:
 				ajaxChat.dom['inputField'].onfocus = '';
-			};		
+			};
 		}
 	},
-	
+
 	startChat: function() {
 		this.chatStarted = true;
 		if(this.dom['inputField'] && this.settings['autoFocus']) {
@@ -306,7 +308,7 @@ var ajaxChat = {
 	loadPageAttributes: function() {
 		var htmlTag			= document.getElementsByTagName('html')[0];
 		this.langCode		= htmlTag.getAttribute('lang')	? htmlTag.getAttribute('lang')	: 'en';
-		this.baseDirection	= htmlTag.getAttribute('dir')	? htmlTag.getAttribute('dir')	: 'ltr';		
+		this.baseDirection	= htmlTag.getAttribute('dir')	? htmlTag.getAttribute('dir')	: 'ltr';
 	},
 
 	setLoadHandler: function() {
@@ -321,9 +323,9 @@ var ajaxChat = {
 				onload();
 				ajaxChat.initialize();
 			};
-		}		
+		}
 	},
-	
+
 	setUnloadHandler: function() {
 		// Make sure finalize() is called on page unload:
   		var onunload = window.onunload;
@@ -359,7 +361,7 @@ var ajaxChat = {
 			this.updateChatlistView();
 		}
 	},
-	
+
 	initializeDocumentNodes: function() {
 		this.dom = {};
 		for(var key in this.domIDs) {
@@ -389,7 +391,7 @@ var ajaxChat = {
  		}
  		this.DOMbuffer = "";
 	},
-	
+
 	initColorCodes: function() {
 		if(this.dom['colorCodesContainer']) {
 			this.DOMbuffer = "";
@@ -424,7 +426,7 @@ var ajaxChat = {
 		}
 		this.updateChat(params);
 	},
-	
+
 	updateChat: function(paramString) {
 		var requestUrl = this.ajaxURL
 						+ '&lastID='
@@ -434,7 +436,7 @@ var ajaxChat = {
 		}
 		this.makeRequest(requestUrl,'GET',null);
 	},
-	
+
 	loadFlashInterface: function() {
 		if(this.dom['flashInterfaceContainer']) {
 			this.updateDOM(
@@ -456,7 +458,7 @@ var ajaxChat = {
 			FABridge.addInitializationCallback('ajaxChat', this.flashInterfaceLoadCompleteHandler);
 		}
 	},
-	
+
 	flashInterfaceLoadCompleteHandler: function() {
 		ajaxChat.initializeFlashInterface();
 	},
@@ -483,13 +485,13 @@ var ajaxChat = {
 				}
 				this.socket.connect(this.socketServerHost, this.socketServerPort);
 			} catch(e) {
-				//alert(e);
+				this.debugMessage('socketConnect', e);
 			}
 		}
 		clearTimeout(this.socketReconnectTimer);
 		this.socketReconnectTimer = null;
 	},
-	
+
 	socketConnectHandler: function(event) {
 		ajaxChat.socketIsConnected = true;
 		// setTimeout is needed to avoid calling the flash interface recursively:
@@ -503,7 +505,7 @@ var ajaxChat = {
 			ajaxChat.updateChat(null);
 		}
 	},
-	
+
 	socketDataHandler: function(event) {
 		ajaxChat.socketUpdate(event.getData());
 	},
@@ -533,11 +535,11 @@ var ajaxChat = {
 					+'"/>'
 				);
 			} catch(e) {
-				//alert(e);
+				this.debugMessage('socketRegister', e);
 			}
 		}
 	},
-	
+
 	loadXML: function(str) {
 		if(!arguments.callee.parser) {
 			try {
@@ -552,7 +554,7 @@ var ajaxChat = {
 							arguments.callee.XMLDOM = new ActiveXObject('Microsoft.XMLDOM');
 						}
 						arguments.callee.XMLDOM.loadXML(str);
-						return arguments.callee.XMLDOM;	
+						return arguments.callee.XMLDOM;
 					};
 				} else {
 					// Safari, Konqueror:
@@ -574,7 +576,7 @@ var ajaxChat = {
 		}
 		return arguments.callee.parser.parseFromString(str, 'text/xml');
 	},
-	
+
 	socketUpdate: function(data) {
 		var xmlDoc = this.loadXML(data);
 		if(xmlDoc) {
@@ -602,15 +604,15 @@ var ajaxChat = {
 			this.settings['audioVolume'] = volume;
 			try {
 				if(!this.soundTransform) {
-					this.soundTransform = FABridge.ajaxChat.create('flash.media.SoundTransform');					
+					this.soundTransform = FABridge.ajaxChat.create('flash.media.SoundTransform');
 				}
 				this.soundTransform.setVolume(volume);
 			} catch(e) {
-				//alert(e);
+				this.debugMessage('setAudioVolume', e);
 			}
 		}
 	},
-	
+
 	loadSounds: function() {
 		try {
 			this.setAudioVolume(this.settings['audioVolume']);
@@ -625,10 +627,10 @@ var ajaxChat = {
 				sound.load(urlRequest);
 			}
 		} catch(e) {
-			alert(e);
+			this.debugMessage('loadSounds', e);
 		}
 	},
-	
+
 	soundLoadCompleteHandler: function(event) {
 		var sound = event.getTarget();
 		for(var key in ajaxChat.soundFiles) {
@@ -645,7 +647,7 @@ var ajaxChat = {
 		setTimeout(function() { ajaxChat.addChatBotMessageToChatList('/error SoundIO'); }, 0);
 		setTimeout(ajaxChat.updateChatlistView, 1);
 	},
-	
+
 	soundPlayCompleteHandler: function(event) {
 		// soundChannel event 'soundComplete'
 	},
@@ -659,12 +661,12 @@ var ajaxChat = {
 				// sndTransform:SoundTransform  (default = null)
 				return this.sounds[soundID].play(0, 0, this.soundTransform);
 			} catch(e) {
-				//alert(e);
+				this.debugMessage('playSound', e);
 			}
 		}
 		return null;
 	},
-	
+
 	playSoundOnNewMessage: function(dateObject, userID, userName, userRole, messageID, messageText, channelID, ip) {
 		if(this.settings['audio'] && this.sounds && this.lastID && !this.channelSwitch) {
 			switch(userID) {
@@ -722,7 +724,7 @@ var ajaxChat = {
 		if (this.requestStatus !== 'retrying' || newStatus === 'ok') {
 			this.requestStatus = newStatus;
 		}
-		
+
 		var statusIcon = document.getElementById('statusIconContainer');
 
 		if (statusIcon) {
@@ -739,12 +741,12 @@ var ajaxChat = {
 			}
 		}
 	},
-	
+
 	forceNewRequest: function() {
-		ajaxChat.updateChat(null); 
+		ajaxChat.updateChat(null);
 		ajaxChat.setStatus('retrying');
 	},
-	
+
 	getHttpRequest: function(identifier) {
 		if(!this.httpRequest[identifier]) {
 			if (window.XMLHttpRequest) {
@@ -769,7 +771,7 @@ var ajaxChat = {
 	makeRequest: function(url, method, data) {
 		var identifier;
 		this.setStatus('waiting');
-		
+
 		try {
 			if(data) {
 				// Create up to 50 HTTPRequest objects:
@@ -784,7 +786,7 @@ var ajaxChat = {
 			}
 			//if the response takes longer than retryTimerDelay to give an OK status, abort the connection and start again.
 			this.retryTimer = setTimeout(ajaxChat.forceNewRequest, ajaxChat.retryTimerDelay);
-			
+
 			this.getHttpRequest(identifier).open(method, url, true);
 			this.getHttpRequest(identifier).onreadystatechange = function() {
 				try {
@@ -793,7 +795,7 @@ var ajaxChat = {
 					try {
 						clearTimeout(ajaxChat.timer);
 					} catch(e) {
-						//alert(e);
+						this.debugMessage('makeRequest::clearTimeout', e);
 					}
 					try {
 						if(data) {
@@ -802,12 +804,12 @@ var ajaxChat = {
 							ajaxChat.updateChatlistView();
 						}
 					} catch(e) {
-						//alert(e);
+						this.debugMessage('makeRequest::logRetry', e);
 					}
-					try {				
+					try {
 						ajaxChat.timer = setTimeout(function() { ajaxChat.updateChat(null); }, ajaxChat.timerRate);
 					} catch(e) {
-						//alert(e);
+						this.debugMessage('makeRequest::setTimeout', e);
 					}
 				}
 			};
@@ -825,7 +827,7 @@ var ajaxChat = {
 			this.timer = setTimeout(function() { ajaxChat.updateChat(null); }, this.timerRate);
 		}
 	},
-		
+
 	handleResponse: function(identifier) {
 		var xmlDoc;
 		if (this.getHttpRequest(identifier).readyState === 4) {
@@ -842,7 +844,7 @@ var ajaxChat = {
 				} else {
 					this.addChatBotMessageToChatList('/error ConnectionStatus '+this.getHttpRequest(identifier).status);
 					this.setStatus('retrying');
-					this.updateChatlistView();				
+					this.updateChatlistView();
 					return false;
 				}
 			}
@@ -853,7 +855,7 @@ var ajaxChat = {
 		this.handleXML(xmlDoc);
 		return true;
 	},
-	
+
 	handleXML: function(xmlDoc) {
 		this.handleInfoMessages(xmlDoc.getElementsByTagName('info'));
 		this.handleOnlineUsers(xmlDoc.getElementsByTagName('user'));
@@ -875,10 +877,10 @@ var ajaxChat = {
 					this.socketReconnectTimer = setTimeout(ajaxChat.socketConnect, 60000);
 				}
 			}
-			this.timer = setTimeout(function() {ajaxChat.updateChat(null);}, timeout);			
+			this.timer = setTimeout(function() {ajaxChat.updateChat(null);}, timeout);
 		}
 	},
-	
+
 	handleInfoMessages: function(infoNodes) {
 		var infoType, infoData;
 		for(var i=0; i<infoNodes.length; i++) {
@@ -887,7 +889,7 @@ var ajaxChat = {
 			this.handleInfoMessage(infoType, infoData);
 		}
 	},
-	
+
 	handleInfoMessage: function(infoType, infoData) {
 		switch(infoType) {
 			case 'channelSwitch':
@@ -896,7 +898,7 @@ var ajaxChat = {
 				this.setSelectedChannel(infoData);
 				this.channelName = infoData;
 				this.channelSwitch = true;
-				break;			
+				break;
 			case 'channelName':
 				this.setSelectedChannel(infoData);
 				this.channelName = infoData;
@@ -906,7 +908,7 @@ var ajaxChat = {
 				break;
 			case 'userID':
 				this.userID = infoData;
-				break;			
+				break;
 			case 'userName':
 				this.userName = infoData;
 				this.encodedUserName = this.scriptLinkEncode(this.userName);
@@ -914,7 +916,7 @@ var ajaxChat = {
 				break;
 			case 'userRole':
 				this.userRole = infoData;
-				break;				
+				break;
 			case 'logout':
 				this.handleLogout(infoData);
 				return;
@@ -956,9 +958,9 @@ var ajaxChat = {
 				if(!this.inArray(onlineUsers, this.usersList[i])) {
 					this.removeUserFromOnlineList(this.usersList[i], i);
 				}
-			}	
-			this.setOnlineListRowClasses();		
-		}	
+			}
+			this.setOnlineListRowClasses();
+		}
 	},
 
 	handleChatMessages: function(messageNodes) {
@@ -987,7 +989,7 @@ var ajaxChat = {
 			this.lastID = messageNodes[messageNodes.length-1].getAttribute('id');
 		}
 	},
-	
+
 	setSelectedChannel: function(channel) {
 		var channelSelected = false,
 			i,option,text;
@@ -1007,7 +1009,7 @@ var ajaxChat = {
 				text = document.createTextNode(channel);
 				option.appendChild(text);
 				option.setAttribute('value', channel);
-				option.setAttribute('selected', 'selected');			
+				option.setAttribute('selected', 'selected');
 				this.dom['channelSelection'].appendChild(option);
 			}
 		}
@@ -1015,15 +1017,15 @@ var ajaxChat = {
 
 	removeUserFromOnlineList: function(userID, index) {
 		this.usersList.splice(index, 1);
-		this.userNamesList.splice(index, 1);		
+		this.userNamesList.splice(index, 1);
 		if(this.dom['onlineList']) {
 			this.dom['onlineList'].removeChild(this.getUserNode(userID));
 		}
 	},
-		
+
 	addUserToOnlineList: function(userID, userName, userRole) {
 		this.usersList.push(userID);
-		this.userNamesList.push(userName);	
+		this.userNamesList.push(userName);
 		if(this.dom['onlineList']) {
 			this.updateDOM(
 				'onlineList',
@@ -1065,12 +1067,12 @@ var ajaxChat = {
 			if(userID === this.userID) {
 				this.userNodeString = str;
 			}
-			return str;	
+			return str;
 		}
 	},
 
 	toggleUserMenu: function(menuID, userName, userID) {
-		// If the menu is empty, fill it with user node menu items before toggling it. 
+		// If the menu is empty, fill it with user node menu items before toggling it.
 		var isInline = false;
 		if (menuID.indexOf('ium') >= 0 ) {
 			isInline = true;
@@ -1090,7 +1092,7 @@ var ajaxChat = {
 		this.showHide(menuID);
 		this.dom['chatList'].scrollTop = this.dom['chatList'].scrollHeight;
 	},
-	
+
 	getUserNodeStringItems: function(encodedUserName, userID, isInline) {
 		var menu;
 		if(encodedUserName !== this.encodedUserName) {
@@ -1182,10 +1184,10 @@ var ajaxChat = {
 		menu += this.getCustomUserMenuItems(encodedUserName, userID);
 		return menu;
 	},
-	
+
 	setOnlineListRowClasses: function() {
 		if(this.dom['onlineList']) {
-			var node = this.dom['onlineList'].firstChild;			
+			var node = this.dom['onlineList'].firstChild;
 			var rowEven = false;
 			while(node) {
 				this.setClass(node, (rowEven ? 'rowEven' : 'rowOdd'));
@@ -1194,7 +1196,7 @@ var ajaxChat = {
 			}
 		}
 	},
-	
+
 	clearChatList: function() {
 		while(this.dom['chatList'].hasChildNodes()) {
 			this.dom['chatList'].removeChild(this.dom['chatList'].firstChild);
@@ -1217,7 +1219,7 @@ var ajaxChat = {
 		}
 		return arguments.callee.encodedChatBotName;
 	},
-	
+
 	addChatBotMessageToChatList: function(messageText) {
 		this.addMessageToChatList(
 			new Date(),
@@ -1229,17 +1231,17 @@ var ajaxChat = {
 			null
 		);
 	},
-	
+
 	addMessageToChatList: function(dateObject, userID, userName, userRole, messageID, messageText, channelID, ip) {
 		// Prevent adding the same message twice:
 		if(this.getMessageNode(messageID)) {
 			return;
-		}		
+		}
 		if(!this.onNewMessage(dateObject, userID, userName, userRole, messageID, messageText, channelID, ip)) {
 			return;
 		}
 		this.DOMbufferRowClass = this.DOMbufferRowClass === 'rowEven' ? 'rowOdd' : 'rowEven';
-		this.DOMbuffer = this.DOMbuffer + 
+		this.DOMbuffer = this.DOMbuffer +
 			this.getChatListMessageString(
 				dateObject, userID, userName, userRole, messageID, messageText, channelID, ip
 			);
@@ -1281,23 +1283,23 @@ var ajaxChat = {
 				+ this.replaceText(messageText)
 				+ '</div>';
 	},
-	
+
 	getChatListUserNameTitle: function(userID, userName, userRole, ip) {
-		return (ip !== null) ? ' title="IP: ' + ip + '"' : '';		
+		return (ip !== null) ? ' title="IP: ' + ip + '"' : '';
 	},
-	
+
 	getMessageDocumentID: function(messageID) {
 		return ((messageID === null) ? 'ajaxChat_lm_'+(this.localID++) : 'ajaxChat_m_'+messageID);
 	},
-	
+
 	getMessageNode: function(messageID) {
 		return ((messageID === null) ? null : document.getElementById(this.getMessageDocumentID(messageID)));
 	},
-	
+
 	getUserDocumentID: function(userID) {
 		return 'ajaxChat_u_'+userID;
 	},
-	
+
 	getUserNode: function(userID) {
 		return document.getElementById(this.getUserDocumentID(userID));
 	},
@@ -1305,11 +1307,11 @@ var ajaxChat = {
 	getUserMenuDocumentID: function(userID) {
 		return 'ajaxChat_um_'+userID;
 	},
-	
+
 	getInlineUserMenuDocumentID: function(menuID, index) {
 		return 'ajaxChat_ium_'+menuID+'_'+index;
 	},
-	
+
 	getDeletionLink: function(messageID, userID, userRole, channelID) {
 		if(messageID !== null && this.isAllowedToDeleteMessage(messageID, userID, userRole, channelID)) {
 			if(!arguments.callee.deleteMessage) {
@@ -1323,7 +1325,7 @@ var ajaxChat = {
 		}
 		return '';
 	},
-	
+
 	isAllowedToDeleteMessage: function(messageID, userID, userRole, channelID) {
 		if((((this.userRole === '1' && this.allowUserMessageDelete && (userID === this.userID ||
 			parseInt(channelID) === parseInt(this.userID)+this.privateMessageDiff ||
@@ -1333,7 +1335,7 @@ var ajaxChat = {
 		}
 		return false;
 	},
-	
+
 	onNewMessage: function(dateObject, userID, userName, userRole, messageID, messageText, channelID, ip) {
 		if(!this.customOnNewMessage(dateObject, userID, userName, userRole, messageID, messageText, channelID, ip)) {
 			return false;
@@ -1367,7 +1369,7 @@ var ajaxChat = {
 		}
 		return false;
 	},
-	
+
 	blinkOnNewMessage: function(dateObject, userID, userName, userRole, messageID, messageText, channelID, ip) {
 		if(this.settings['blink'] && this.lastID && !this.channelSwitch && userID !== this.userID) {
 			clearInterval(this.blinkInterval);
@@ -1377,7 +1379,7 @@ var ajaxChat = {
 			);
 		}
 	},
-	
+
 	blinkUpdate: function(blinkStr) {
 		if(!this.originalDocumentTitle) {
 			this.originalDocumentTitle = document.title;
@@ -1398,19 +1400,19 @@ var ajaxChat = {
 			arguments.callee.blink++;
 		}
 	},
-	
-	updateChatlistView: function() {		
+
+	updateChatlistView: function() {
 		if(this.dom['chatList'].childNodes && this.settings['maxMessages']) {
 			while(this.dom['chatList'].childNodes.length > this.settings['maxMessages']) {
 				this.dom['chatList'].removeChild(this.dom['chatList'].firstChild);
 			}
 		}
-		
+
 		if(this.settings['autoScroll']) {
 			this.dom['chatList'].scrollTop = this.dom['chatList'].scrollHeight;
 		}
 	},
-	
+
 	encodeText: function(text) {
 		return encodeURIComponent(text);
 	},
@@ -1466,7 +1468,7 @@ var ajaxChat = {
 			this.encodeSpecialCharsCallback
 		);
 	},
-	
+
 	encodeSpecialCharsCallback: function(str) {
 		switch(str) {
 			case '&':
@@ -1487,13 +1489,13 @@ var ajaxChat = {
 
 	decodeSpecialChars: function(text) {
 		var regExp = new RegExp('(&amp;)|(&lt;)|(&gt;)|(&#39;)|(&quot;)', 'g');
-		
+
 		return text.replace(
 			regExp,
 			this.decodeSpecialCharsCallback
 		);
 	},
-	
+
 	decodeSpecialCharsCallback: function(str) {
 		switch(str) {
 			case '&amp;':
@@ -1510,7 +1512,7 @@ var ajaxChat = {
 				return str;
 		}
 	},
-	
+
 	inArray: function(haystack, needle) {
 		var i = haystack.length;
 		while(i--) {
@@ -1535,7 +1537,7 @@ var ajaxChat = {
 		if (!arguments.callee.regExp) {
 			arguments.callee.regExp = new RegExp('<\\/?[^>]+?>', 'g');
 		}
-		
+
 		return str.replace(arguments.callee.regExp, '');
 	},
 
@@ -1543,9 +1545,9 @@ var ajaxChat = {
 		if (!arguments.callee.regExp) {
 			arguments.callee.regExp = new RegExp('\\[\\/?[^\\]]+?\\]', 'g');
 		}
-		
+
 		return str.replace(arguments.callee.regExp, '');
-	},	
+	},
 
 	escapeRegExp: function(text) {
 		if (!arguments.callee.regExp) {
@@ -1559,7 +1561,7 @@ var ajaxChat = {
 		}
 		return text.replace(arguments.callee.regExp, '\\$1');
 	},
-	
+
 	addSlashes: function(text) {
 		// Adding slashes in front of apostrophs and backslashes to ensure a valid JavaScript expression:
 		return text.replace(/\\/g, '\\\\').replace(/\'/g, '\\\'');
@@ -1572,7 +1574,7 @@ var ajaxChat = {
 
 	formatDate: function(format, date) {
 		date = (date == null) ? new date() : date;
-		
+
 		return format
 		.replace(/%Y/g, date.getFullYear())
 		.replace(/%m/g, this.addLeadingZero(date.getMonth()+1))
@@ -1581,7 +1583,7 @@ var ajaxChat = {
 		.replace(/%i/g, this.addLeadingZero(date.getMinutes()))
 		.replace(/%s/g, this.addLeadingZero(date.getSeconds()));
 	},
-	
+
 	addLeadingZero: function(number) {
 		number = number.toString();
 		if(number.length < 2) {
@@ -1622,7 +1624,7 @@ var ajaxChat = {
 				return 'default';
 		}
 	},
-	
+
 	handleInputFieldKeyPress: function(event) {
 		if(event.keyCode === 13 && !event.shiftKey) {
 			this.sendMessage();
@@ -1639,7 +1641,7 @@ var ajaxChat = {
 	handleInputFieldKeyUp: function(event) {
 		this.updateMessageLengthCounter();
 	},
-	
+
 	updateMessageLengthCounter: function() {
 		if(this.dom['messageLengthCounter']) {
 			this.updateDOM(
@@ -1650,7 +1652,7 @@ var ajaxChat = {
 			);
 		}
 	},
-	
+
 	sendMessage: function(text) {
 		text = text ? text : this.dom['inputField'].value;
 		if(!text) {
@@ -1662,14 +1664,14 @@ var ajaxChat = {
 			var message = 	'lastID='
 							+ this.lastID
 							+ '&text='
-							+ this.encodeText(text);				
+							+ this.encodeText(text);
 			this.makeRequest(this.ajaxURL,'POST',message);
 		}
 		this.dom['inputField'].value = '';
 		this.dom['inputField'].focus();
 		this.updateMessageLengthCounter();
 	},
-	
+
 	parseInputMessage: function(text) {
 		var textParts;
 		if(text.charAt(0) === '/') {
@@ -1696,7 +1698,7 @@ var ajaxChat = {
 		}
 		return text;
 	},
-	
+
 	assignFontColorToMessage: function(text) {
 		return '[color='+this.settings['fontColor']+']'+text+'[/color]';
 	},
@@ -1724,7 +1726,7 @@ var ajaxChat = {
 		}
 		return text;
 	},
-	
+
 	parseIgnoreInputCommand: function(text, textParts) {
 		var userName, ignoredUserNames = this.getIgnoredUserNames(), i;
 		if(textParts.length > 1) {
@@ -1772,12 +1774,12 @@ var ajaxChat = {
 		}
 		return this.ignoredUserNames;
 	},
-	
+
 	setIgnoredUserNames: function(ignoredUserNames) {
 		this.ignoredUserNames = ignoredUserNames;
 		this.setSetting('ignoredUserNames', ignoredUserNames.join(' '));
 	},
-	
+
 	ignoreMessage: function(dateObject, userID, userName, userRole, messageID, messageText, channelID, ip) {
 		var textParts;
 		if(userID === this.chatBotID && messageText.charAt(0) === '/') {
@@ -1789,7 +1791,7 @@ var ajaxChat = {
 					case '/roll':
 						userName = textParts[1];
 						break;
-				}	
+				}
 			}
 		}
 		if(this.inArray(this.getIgnoredUserNames(), userName)) {
@@ -1835,7 +1837,7 @@ var ajaxChat = {
 			}
 		}
 	},
-	
+
 	getClass: function(node) {
 		if(typeof node.className !== 'undefined') {
 			return node.className; // IE
@@ -1843,7 +1845,7 @@ var ajaxChat = {
 			return node.getAttribute('class');
 		}
 	},
-	
+
 	setClass: function(node, className) {
 		if(typeof node.className !== 'undefined') {
 			node.className = className; // IE
@@ -1855,7 +1857,7 @@ var ajaxChat = {
 	scriptLinkEncode: function(text) {
 		return this.encodeText(this.addSlashes(this.decodeSpecialChars(text)));
 	},
-	
+
 	scriptLinkDecode: function(text) {
 		return this.encodeSpecialChars(this.removeSlashes(this.decodeText(text)));
 	},
@@ -1872,9 +1874,9 @@ var ajaxChat = {
 				default:
 					arguments.callee.utf8Decode = false;
 					return value;
-			}	
+			}
 		} else if(arguments.callee.utf8Decode) {
-			return this.utf8Decode(value);	
+			return this.utf8Decode(value);
 		} else {
 			return value;
 		}
@@ -1887,7 +1889,7 @@ var ajaxChat = {
 	insertMessageWrapper: function(text) {
 		this.insertText(this.getScriptLinkValue(text), true);
 	},
-	
+
 	switchChannel: function(channel) {
 		if(!this.chatStarted) {
 			this.clearChatList();
@@ -1897,11 +1899,11 @@ var ajaxChat = {
 			this.requestTeaserContent();
 			return;
 		}
-		clearTimeout(this.timer);	
+		clearTimeout(this.timer);
 		var message = 	'lastID='
 						+ this.lastID
 						+ '&channelName='
-						+ this.encodeText(channel);		
+						+ this.encodeText(channel);
 		this.makeRequest(this.ajaxURL,'POST',message);
 		if(this.dom['inputField'] && this.settings['autoFocus']) {
 			this.dom['inputField'].focus();
@@ -1913,7 +1915,7 @@ var ajaxChat = {
 		var message = 'logout=true';
 		this.makeRequest(this.ajaxURL,'POST',message);
 	},
-	
+
 	handleLogout: function(url) {
 		window.location.href = url;
 	},
@@ -1931,7 +1933,7 @@ var ajaxChat = {
 			this.setClass(node, (this.getSetting(setting) ? 'button' : 'button off'));
 		}
 	},
-	
+
 	showHide: function(id, styleDisplay, displayInline) {
 		var node = document.getElementById(id);
 		if(node) {
@@ -1939,16 +1941,16 @@ var ajaxChat = {
 				node.style.display = styleDisplay;
 			} else {
 				if(node.style.display === 'none') {
-					node.style.display = (displayInline ? 'inline' : 'block'); 
+					node.style.display = (displayInline ? 'inline' : 'block');
 				} else {
 					node.style.display = 'none';
 				}
-			}	
+			}
 		}
 	},
 
 	setPersistFontColor: function(bool) {
-		this.settings['persistFontColor'] = bool;		
+		this.settings['persistFontColor'] = bool;
 		if(!this.settings['persistFontColor']) {
 			this.settings['fontColor'] = null;
 			if(this.dom['inputField']) {
@@ -1973,16 +1975,16 @@ var ajaxChat = {
 			this.insert('[color=' + color + ']', '[/color]');
 		}
 	},
-	
+
 	insertText: function(text, clearInputField) {
 		if(clearInputField) {
 			this.dom['inputField'].value = '';
 		}
 		this.insert(text, '');
 	},
-	
+
 	insertBBCode: function(bbCode) {
-		switch(bbCode) {			
+		switch(bbCode) {
 			case 'url':
 				var url = prompt(this.lang['urlDialog'], 'http://');
 				if(url)
@@ -1991,7 +1993,7 @@ var ajaxChat = {
 					this.dom['inputField'].focus();
 				break;
 			default:
-				this.insert('[' + bbCode + ']', '[/' + bbCode + ']');		
+				this.insert('[' + bbCode + ']', '[/' + bbCode + ']');
 		}
 	},
 
@@ -2008,7 +2010,7 @@ var ajaxChat = {
 			if (insText.length === 0) {
 				range.move('character', -endTag.length);
 			} else {
-				range.moveStart('character', startTag.length + insText.length + endTag.length);			
+				range.moveStart('character', startTag.length + insText.length + endTag.length);
 			}
 			range.select();
 		}
@@ -2042,7 +2044,7 @@ var ajaxChat = {
 											+ this.dom['inputField'].value.substr(pos);
 		}
 	},
-	
+
 	replaceText: function(text) {
 		try{
 			text = this.replaceLineBreaks(text);
@@ -2053,20 +2055,20 @@ var ajaxChat = {
 				text = this.replaceHyperLinks(text);
 				text = this.replaceEmoticons(text);
 			}
-			text = this.breakLongWords(text);		
+			text = this.breakLongWords(text);
 			text = this.replaceCustomText(text);
 		} catch(e){
-			//alert(e);
+			this.debugMessage('replaceText', e);
 		}
 		return text;
 	},
-	
+
 	replaceCommands: function(text) {
 		try {
 			if(text.charAt(0) !== '/') {
 				return text;
 			}
-			var textParts = text.split(' ');				
+			var textParts = text.split(' ');
 			switch(textParts[0]) {
 				case '/login':
 					return this.replaceCommandLogin(textParts);
@@ -2137,7 +2139,7 @@ var ajaxChat = {
 					return this.replaceCustomCommands(text, textParts);
 			}
 		} catch(e) {
-			//alert(e);
+			this.debugMessage('replaceCommands', e);
 		}
 		return text;
 	},
@@ -2145,7 +2147,7 @@ var ajaxChat = {
 	replaceCommandLogin: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['login'].replace(/%s/, textParts[1])
-				+ '</span>';		
+				+ '</span>';
 	},
 
 	replaceCommandLogout: function(textParts) {
@@ -2154,21 +2156,21 @@ var ajaxChat = {
 			type = textParts[2];
 		return	'<span class="chatBotMessage">'
 				+ this.lang['logout' + type].replace(/%s/, textParts[1])
-				+ '</span>';		
+				+ '</span>';
 	},
-	
+
 	replaceCommandChannelEnter: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['channelEnter'].replace(/%s/, textParts[1])
-				+ '</span>';		
+				+ '</span>';
 	},
-	
+
 	replaceCommandChannelLeave: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['channelLeave'].replace(/%s/, textParts[1])
-				+ '</span>';		
+				+ '</span>';
 	},
-	
+
 	replaceCommandPrivMsg: function(textParts) {
 		var privMsgText = textParts.slice(1).join(' ');
 		privMsgText = this.replaceBBCode(privMsgText);
@@ -2179,7 +2181,7 @@ var ajaxChat = {
 				+ '</span> '
 				+ privMsgText;
 	},
-	
+
 	replaceCommandPrivMsgTo: function(textParts) {
 		var privMsgText = textParts.slice(2).join(' ');
 		privMsgText = this.replaceBBCode(privMsgText);
@@ -2190,7 +2192,7 @@ var ajaxChat = {
 				+ '</span> '
 				+ privMsgText;
 	},
-	
+
 	replaceCommandPrivAction: function(textParts) {
 		var privActionText = textParts.slice(1).join(' ');
 		privActionText = this.replaceBBCode(privActionText);
@@ -2202,7 +2204,7 @@ var ajaxChat = {
 				+ this.lang['privmsg']
 				+ '</span> ';
 	},
-	
+
 	replaceCommandPrivActionTo: function(textParts) {
 		var privActionText = textParts.slice(2).join(' ');
 		privActionText = this.replaceBBCode(privActionText);
@@ -2212,9 +2214,9 @@ var ajaxChat = {
 				+ privActionText
 				+ '</span> <span class="privmsg">'
 				+ this.lang['privmsgto'].replace(/%s/, textParts[1])
-				+ '</span> ';		
+				+ '</span> ';
 	},
-	
+
 	replaceCommandAction: function(textParts) {
 		var actionText = textParts.slice(1).join(' ');
 		actionText = this.replaceBBCode(actionText);
@@ -2222,9 +2224,9 @@ var ajaxChat = {
 		actionText = this.replaceEmoticons(actionText);
 		return	'<span class="action">'
 				+ actionText
-				+ '</span>';		
+				+ '</span>';
 	},
-	
+
 	replaceCommandInvite: function(textParts) {
 		var inviteText = this.lang['invite']
 							.replace(/%s/, textParts[1])
@@ -2240,99 +2242,99 @@ var ajaxChat = {
 							);
 		return	'<span class="chatBotMessage">'
 				+ inviteText
-				+ '</span>';		
+				+ '</span>';
 	},
-	
+
 	replaceCommandInviteTo: function(textParts) {
 		var inviteText = this.lang['inviteto']
 							.replace(/%s/, textParts[1])
 							.replace(/%s/, textParts[2]);
 		return	'<span class="chatBotMessage">'
 				+ inviteText
-				+ '</span>';		
+				+ '</span>';
 	},
-	
+
 	replaceCommandUninvite: function(textParts) {
 		var uninviteText = this.lang['uninvite']
 							.replace(/%s/, textParts[1])
 							.replace(/%s/, textParts[2]);
 		return	'<span class="chatBotMessage">'
 				+ uninviteText
-				+ '</span>';		
+				+ '</span>';
 	},
-	
+
 	replaceCommandUninviteTo: function(textParts) {
 		var uninviteText = this.lang['uninviteto']
 							.replace(/%s/, textParts[1])
 							.replace(/%s/, textParts[2]);
 		return	'<span class="chatBotMessage">'
 				+ uninviteText
-				+ '</span>';		
+				+ '</span>';
 	},
-	
+
 	replaceCommandQueryOpen: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['queryOpen'].replace(/%s/, textParts[1])
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandQueryClose: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['queryClose'].replace(/%s/, textParts[1])
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandIgnoreAdded: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['ignoreAdded'].replace(/%s/, textParts[1])
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandIgnoreRemoved: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['ignoreRemoved'].replace(/%s/, textParts[1])
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandIgnoreList: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['ignoreList'] + ' '
 				+ this.getInlineUserMenu(textParts.slice(1))
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandIgnoreListEmpty: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['ignoreListEmpty']
-				+ '</span>';			
+				+ '</span>';
 	},
-		
+
 	replaceCommandKick: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['logoutKicked'].replace(/%s/, textParts[1])
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandWho: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['who'] + ' '
 				+ this.getInlineUserMenu(textParts.slice(1))
-				+ '</span>';		
+				+ '</span>';
 	},
 
 	replaceCommandWhoChannel: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['whoChannel'].replace(/%s/, textParts[1]) + ' '
 				+ this.getInlineUserMenu(textParts.slice(2))
-				+ '</span>';		
+				+ '</span>';
 	},
-	
+
 	replaceCommandWhoEmpty: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['whoEmpty']
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandList: function(textParts) {
 		var channels = textParts.slice(1);
 		var listChannels = [];
@@ -2352,9 +2354,9 @@ var ajaxChat = {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['list'] + ' '
 				+ listChannels.join(', ')
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandBans: function(textParts) {
 		var users = textParts.slice(1);
 		var listUsers = [];
@@ -2372,26 +2374,26 @@ var ajaxChat = {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['bans'] + ' '
 				+ listUsers.join(', ')
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandBansEmpty: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['bansEmpty']
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandUnban: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['unban'].replace(/%s/, textParts[1])
-				+ '</span>';		
+				+ '</span>';
 	},
-	
+
 	replaceCommandWhois: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['whois'].replace(/%s/, textParts[1]) + ' '
 				+ textParts[2]
-				+ '</span>';		
+				+ '</span>';
 	},
 
 	replaceCommandWhereis: function(textParts) {
@@ -2406,24 +2408,24 @@ var ajaxChat = {
 								+ textParts[2]
 								+ '</a>'
 							)
-				+ '</span>';		
+				+ '</span>';
 	},
-	
+
 	replaceCommandRoll: function(textParts) {
 		var rollText = this.lang['roll'].replace(/%s/, textParts[1]);
 		rollText = rollText.replace(/%s/, textParts[2]);
 		rollText = rollText.replace(/%s/, textParts[3]);
 		return	'<span class="chatBotMessage">'
 				+ rollText
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandNick: function(textParts) {
 		return	'<span class="chatBotMessage">'
 				+ this.lang['nick'].replace(/%s/, textParts[1]).replace(/%s/, textParts[2])
-				+ '</span>';		
+				+ '</span>';
 	},
-		
+
 	replaceCommandError: function(textParts) {
 		var errorMessage = this.lang['error'+textParts[1]];
 		if(!errorMessage) {
@@ -2433,7 +2435,7 @@ var ajaxChat = {
 		}
 		return	'<span class="chatBotErrorMessage">'
 				+ errorMessage
-				+ '</span>';		
+				+ '</span>';
 	},
 
 	getInlineUserMenu: function(users) {
@@ -2466,7 +2468,7 @@ var ajaxChat = {
 		var openTags, closeTags,
 			regExpOpenTags = /<[^>\/]+?>/gm,
 			regExpCloseTags = /<\/[^>]+?>/gm;
-	
+
 		openTags	= str.match(regExpOpenTags);
 		closeTags	= str.match(regExpCloseTags);
 		// Return true if the number of tags doesn't match:
@@ -2477,32 +2479,32 @@ var ajaxChat = {
 		}
 		return false;
 	},
-		
+
 	breakLongWords: function(text) {
 		var newText, charCounter, currentChar, withinTag, withinEntity, i;
-	
+
 		if(!this.settings['wordWrap'])
 			return text;
-		
+
 		newText = '';
 		charCounter = 0;
-		
+
 		for(i=0; i<text.length; i++) {
 			currentChar = text.charAt(i);
-			
+
 			// Check if we are within a tag or entity:
 			if(currentChar === '<') {
 				withinTag = true;
 				// Reset the charCounter after newline tags (<br/>):
 				if(i>5 && text.substr(i-5,4) === '<br/')
-					charCounter = 0;				
+					charCounter = 0;
 			} else if(withinTag && i>0 && text.charAt(i-1) === '>') {
 				withinTag = false;
 				// Reset the charCounter after newline tags (<br/>):
 				if(i>4 && text.substr(i-5,4) === '<br/')
 					charCounter = 0;
 			}
-			
+
 			if(!withinTag && currentChar === '&') {
 				withinEntity = true;
 			} else if(withinEntity && i>0 && text.charAt(i-1) === ';') {
@@ -2510,7 +2512,7 @@ var ajaxChat = {
 				// We only increase the charCounter once for the whole entiy:
 				charCounter++;
 			}
-				
+
 			if(!withinTag && !withinEntity) {
 				// Reset the charCounter if we encounter a word boundary:
 				if(currentChar === ' ' || currentChar === '\n' || currentChar === '\t') {
@@ -2524,14 +2526,14 @@ var ajaxChat = {
 					newText += '&#8203;';
 					charCounter = 0;
 				}
-			}		
+			}
 			// Add the current char to the text:
 			newText += currentChar;
 		}
-		
+
 		return newText;
 	},
-	
+
 	replaceBBCode: function(text) {
 		if(!this.settings['bbCode']) {
 			// If BBCode is disabled, just strip the text from BBCode tags:
@@ -2539,11 +2541,11 @@ var ajaxChat = {
 		}
 		// Remove the BBCode tags:
 		return text.replace(
-			/\[(\w+)(?:=([^<>]*?))?\](.+?)\[\/\1\]/gm, 
+			/\[(\w+)(?:=([^<>]*?))?\](.+?)\[\/\1\]/gm,
 			this.replaceBBCodeCallback
 		);
 	},
-	
+
 	replaceBBCodeCallback: function(str, p1, p2, p3) {
 		// Only replace predefined BBCode tags:
 		if(!ajaxChat.inArray(ajaxChat.bbCodeTags, p1)) {
@@ -2552,7 +2554,7 @@ var ajaxChat = {
 		// Avoid invalid XHTML (unclosed tags):
 		if(ajaxChat.containsUnclosedTags(p3)) {
 			return str;
-		}	
+		}
 		switch(p1) {
 			case 'color':
 				return ajaxChat.replaceBBCodeColor(p3, p2);
@@ -2575,7 +2577,7 @@ var ajaxChat = {
 		if(this.settings['bbCodeColors']) {
 			// Only allow predefined color codes:
 			if(!attribute || !this.inArray(ajaxChat.colorCodes, attribute))
-				return content;								
+				return content;
 			return 	'<span style="color:'
 					+ attribute + ';">'
 					+ this.replaceBBCode(content)
@@ -2583,7 +2585,7 @@ var ajaxChat = {
 		}
 		return content;
 	},
-	
+
 	replaceBBCodeUrl: function(content, attribute) {
 		var url, regExpUrl;
 		if(attribute)
@@ -2602,7 +2604,7 @@ var ajaxChat = {
 				+ this.replaceBBCode(content)
 				+ '</a>';
 	},
-	
+
 	replaceBBCodeImage: function(url) {
 		var regExpUrl, maxWidth, maxHeight;
 		if(this.settings['bbCodeImages']) {
@@ -2647,13 +2649,13 @@ var ajaxChat = {
 				+ this.replaceBBCode(content.replace(/\t|(?:  )/gm, '&#160;&#160;'))
 				+ '</code>';
 	},
-	
+
 	replaceBBCodeUnderline: function(content) {
 		return 	'<span style="text-decoration:underline;">'
 				+ this.replaceBBCode(content)
 				+ '</span>';
 	},
-	
+
 	replaceHyperLinks: function(text) {
 		var regExp;
 		if(!this.settings['hyperLinks']) {
@@ -2706,11 +2708,11 @@ var ajaxChat = {
 			arguments.callee.regExp = new RegExp(regExpStr, 'gm');
 		}
 		return text.replace(
-			arguments.callee.regExp,			
+			arguments.callee.regExp,
 			this.replaceEmoticonsCallback
 		);
 	},
-	
+
 	replaceEmoticonsCallback: function(str, p1, p2, p3) {
 		if (!arguments.callee.regExp) {
 			arguments.callee.regExp = new RegExp('(="[^"]*$)|(&[^;]*$)', '');
@@ -2718,9 +2720,9 @@ var ajaxChat = {
 		// Avoid replacing emoticons in tag attributes or XHTML entities:
 		if(p1.match(arguments.callee.regExp)) {
 			return str;
-		}	
+		}
 		if(p2) {
-			var index = ajaxChat.arraySearch(p2, ajaxChat.emoticonCodes);							
+			var index = ajaxChat.arraySearch(p2, ajaxChat.emoticonCodes);
 			return 	ajaxChat.replaceEmoticons(p1)
 				+	'<img src="'
 				+	ajaxChat.dirs['emoticons']
@@ -2732,24 +2734,24 @@ var ajaxChat = {
 		}
 		return str;
 	},
-	
+
 	getActiveStyle: function() {
 		var cookie = this.readCookie(this.sessionName + '_style');
 		var style = cookie ? cookie : this.getPreferredStyleSheet();
-		return style;		
+		return style;
 	},
 
 	initStyle: function() {
 		this.styleInitiated = true;
 		this.setActiveStyleSheet(this.getActiveStyle());
 	},
-	
+
 	persistStyle: function() {
 		if(this.styleInitiated) {
 			this.createCookie(this.sessionName + '_style', this.getActiveStyleSheet(), this.cookieExpiration);
 		}
 	},
-	
+
 	setSelectedStyle: function() {
 		if(this.dom['styleSelection']) {
 			var style = this.getActiveStyle();
@@ -2762,7 +2764,7 @@ var ajaxChat = {
 			}
 		}
 	},
-	
+
 	getSelectedStyle: function() {
 		var styleOptions = this.dom['styleSelection'].getElementsByTagName('option');
 		if(this.dom['styleSelection'].selectedIndex === -1) {
@@ -2771,7 +2773,7 @@ var ajaxChat = {
 			return styleOptions[this.dom['styleSelection'].selectedIndex].value;
 		}
 	},
-	
+
 	setActiveStyleSheet: function(title) {
 		var i, a, main, titleFound = false;
 		for(i=0; (a = document.getElementsByTagName('link')[i]); i++) {
@@ -2787,7 +2789,7 @@ var ajaxChat = {
 		   this.setActiveStyleSheet(this.getPreferredStyleSheet());
 		}
 	},
-	
+
 	getActiveStyleSheet: function() {
 		var i, a;
 		for(i=0; (a = document.getElementsByTagName('link')[i]); i++) {
@@ -2797,7 +2799,7 @@ var ajaxChat = {
 		}
 		return null;
 	},
-	
+
 	getPreferredStyleSheet: function() {
 		var i,a;
 		for(i=0; (a = document.getElementsByTagName('link')[i]); i++) {
@@ -2814,7 +2816,7 @@ var ajaxChat = {
 	switchLanguage: function(langCode) {
 		window.location.search = '?lang='+langCode;
 	},
-	
+
 	createCookie: function(name,value,days) {
 		var expires = '';
 		if(days) {
@@ -2827,7 +2829,7 @@ var ajaxChat = {
 		var secure = this.cookieSecure ? '; secure' : '';
 		document.cookie = name+'='+encodeURIComponent(value)+expires+path+domain+secure;
 	},
-	
+
 	readCookie: function(name) {
 		if(!document.cookie)
 		   return null;
@@ -2856,8 +2858,8 @@ var ajaxChat = {
 		}
 		return false;
 	},
-	
-	finalize: function() {	
+
+	finalize: function() {
 		if(typeof this.finalizeFunction === 'function') {
 			this.finalizeFunction();
 		}
@@ -2867,30 +2869,30 @@ var ajaxChat = {
 				this.socket.close();
 				this.socket = null;
 			} catch(e) {
-				//alert(e);
+				this.debugMessage('finalize::closeSocket', e);
 			}
-		}	
+		}
 		this.persistSettings();
-		this.persistStyle();		
+		this.persistStyle();
 		this.customFinalize();
 	},
 
 	// Override to perform custom actions on flash initialization:
-	initializeCustomFlashInterface: function() {	
+	initializeCustomFlashInterface: function() {
 	},
-	
+
 	// Override to handle custom info messages
 	handleCustomInfoMessage: function(infoType, infoData) {
 	},
 
 	// Override to add custom initialization code
 	// This method is called on page load
-	customInitialize: function() {		
+	customInitialize: function() {
 	},
 
 	// Override to add custom finalization code
 	// This method is called on page unload
-	customFinalize: function() {	
+	customFinalize: function() {
 	},
 
 	// Override to add custom user menu items:
@@ -2908,21 +2910,21 @@ var ajaxChat = {
 	parseCustomInputMessage: function(text) {
 		return text;
 	},
-	
+
 	// Override to parse custom input commands:
 	// Return parsed text
 	// text contains the whole message, textParts the message split up as words array
 	parseCustomInputCommand: function(text, textParts) {
 		return text;
 	},
-	
+
 	// Override to replace custom text:
 	// Return replaced text
 	// text contains the whole message
 	replaceCustomText: function(text) {
 		return text;
 	},
-	
+
 	// Override to replace custom commands:
 	// Return replaced text for custom commands
 	// text contains the whole message, textParts the message split up as words array
@@ -2937,11 +2939,21 @@ var ajaxChat = {
 	replaceCustomBBCode: function(tag, attribute, content) {
 		return '<' + tag + '>' + this.replaceBBCode(content) + '</' + tag + '>';
 	},
-	
+
 	// Override to perform custom actions on new messages:
 	// Return true if message is to be added to the chatList, else false
 	customOnNewMessage: function(dateObject, userID, userName, userRole, messageID, messageText, channelID, ip) {
 		return true;
-	}
+	},
+
+	debugMessage: function(msg, e) {
+		msg = 'Ajax chat: ' + msg + ' exception: ';
+		if (this.debug) {
+			console.log(msg, e);
+			if (this.debug == '2') {
+				alert(msg + e);
+			}
+		}
+	},
 
 };

--- a/chat/js/chat.js
+++ b/chat/js/chat.js
@@ -150,7 +150,22 @@ var ajaxChat = {
 		this.debug					= config['debug'];
 		this.DOMbuffering			= false;
 		this.DOMbuffer				= "";
+		/**
+		 * The calculation below looks incorrect - inactiveTimeout is in minutes, timerRate is in ms.
 		this.retryTimerDelay 		= (this.inactiveTimeout*6000 - this.timerRate)/4 + this.timerRate;
+		 * So I think inactiveTimeout should be multiplied by 60000 not 6000.
+		 * With original calc and inactive timeout = the minimum of 2 mins and timerRate of 2s, this would result in
+		 * an ajax retry delay of 4.5secs which is unreasonable on a slow connection.
+		 * With corrected calc and inactive timeout = the minimum of 2 mins and timerRate of 2s, this would result in
+		 * an ajax retry delay of 31.5secs which is about the maximum we should allow.
+		 * With original calc and inactive timeout = 15 mins and timerRate of 2s, this would result in
+		 * an ajax retry delay of 24secs which is reasonable.
+		 * With corrected calc and inactive timeout = 15 mins and timerRate of 2s, this would result in
+		 * an ajax retry delay of 226secs which is 3 mins and is unreasonable.
+		 * Calc looks to allow at least 4 retries before user becomes inactive which seems reasonable.
+		 * However with large inactiveTimeouts, the retry period should be limited.
+		 **/
+		this.retryTimerDelay 		= Math.min(this.inactiveTimeout*15000, 60000);
 	},
 
 	initDirectories: function() {

--- a/chat/js/config.js
+++ b/chat/js/config.js
@@ -12,11 +12,11 @@ var ajaxChatConfig = {
 	// The channelID of the channel to enter on login (the loginChannelName is used if set to null):
 	loginChannelID: null,
 	// The channelName of the channel to enter on login (the default channel is used if set to null):
-	loginChannelName: null,	
-	
+	loginChannelName: null,
+
 	// The time in ms between update calls to retrieve new chat messages:
 	timerRate: 2000,
-	
+
 	// The URL to retrieve the XML chat messages (must at least contain one parameter):
 	ajaxURL: './?ajax=true',
 	// The base URL of the chat directory, used to retrieve media files (images, sound files, etc.):
@@ -24,10 +24,10 @@ var ajaxChatConfig = {
 
 	// A regular expression for allowed source URL's for media content (e.g. images displayed inline);
 	regExpMediaUrl: '^((http)|(https)):\\/\\/',
-	
+
 	// If set to false the chat update is delayed until the event defined in ajaxChat.setStartChatHandler():
 	startChatOnLoad: true,
-	
+
 	// Defines the IDs of DOM nodes accessed by the chat:
 	domIDs: {
 		// The ID of the chat messages list:
@@ -64,27 +64,27 @@ var ajaxChatConfig = {
 		lineBreaks: true,
 		// Defines if emoticon codes are replaced with their associated images:
 		emoticons: true,
-	
+
 		// Defines if the focus is automatically set to the input field on chat load or channel switch:
 		autoFocus: true,
 		// Defines if the chat list scrolls automatically to display the latest messages:
-		autoScroll: true,	
+		autoScroll: true,
 		// The maximum count of messages displayed in the chat list (will be ignored if set to 0):
 		maxMessages: 0,
-		
+
 		// Defines if long words are wrapped to avoid vertical scrolling:
 		wordWrap: true,
-		// Defines the maximum length before a word gets wrapped: 
+		// Defines the maximum length before a word gets wrapped:
 		maxWordLength: 32,
-		
+
 		// Defines the format of the date and time displayed for each chat message:
 		dateFormat: '(%H:%i:%s)',
-		
+
 		// Defines if font colors persist without the need to assign them to each message:
-		persistFontColor: false,	
+		persistFontColor: false,
 		// The default font color, uses the page default font color if set to null:
 		fontColor: null,
-		
+
 		// Defines if sounds are played:
 		audio: true,
 		// Defines the sound volume (0.0 = mute, 1.0 = max):
@@ -104,7 +104,7 @@ var ajaxChatConfig = {
 		soundError: 'sound_6',
 		// Defines the sound that is played when private messages are received:
         	soundPrivate: 'sound_7',
-		
+
 		// Defines if the document title blinks on new messages:
 		blink: true,
 		// Defines the blink interval in ms:
@@ -112,7 +112,7 @@ var ajaxChatConfig = {
 		// Defines the number of blink intervals:
 		blinkIntervalNumber: 10
 	},
-	
+
 	// Defines a list of settings which are not to be stored in a session cookie:
 	nonPersistentSettings: [],
 
@@ -127,12 +127,12 @@ var ajaxChatConfig = {
 		'url',
 		'img'
 	],
-	
+
 	// Defines the list of allowed color codes:
 	colorCodes: [
 		'gray',
 		'silver',
-		'white',	
+		'white',
 		'yellow',
 		'orange',
 		'red',
@@ -148,7 +148,7 @@ var ajaxChatConfig = {
 		'maroon',
 		'black'
 	],
-	
+
 	// Defines the list of allowed emoticon codes:
 	emoticonCodes: [
 		':)',
@@ -173,9 +173,9 @@ var ajaxChatConfig = {
 		':help:',
 		':error:',
 		':warning:',
-		':favorite:'		
+		':favorite:'
  	],
-	
+
  	// Defines the list of emoticon files associated with the emoticon codes:
 	emoticonFiles: [
 		'smile.png',
@@ -213,11 +213,11 @@ var ajaxChatConfig = {
 		sound_6: 'sound_6.mp3',
 		sound_7: 'sound_1.mp3'
 	},
-	
-	
+
+
 	// Once users have been logged in, the following values are overridden by those in config.php.
 	// You should set these to be the same as the ones in config.php to avoid confusion.
-	
+
 	// Session identification, used for style and setting cookies:
 	sessionName: 'ajax_chat',
 
@@ -229,7 +229,7 @@ var ajaxChatConfig = {
 	cookieDomain: null,
 	// If enabled, cookies must be sent over secure (SSL/TLS encrypted) connections:
 	cookieSecure: null,
-	
+
 	// The name of the chat bot:
 	chatBotName: 'ChatBot',
 	// The userID of the chat bot:
@@ -237,7 +237,7 @@ var ajaxChatConfig = {
 
 	// Allow/Disallow registered users to delete their own messages:
 	allowUserMessageDelete: true,
-	
+
 	// Minutes until a user is declared inactive (last status update) - the minimum is 2 minutes:
 	inactiveTimeout: 2,
 
@@ -251,7 +251,7 @@ var ajaxChatConfig = {
 
 	// Max messageText length:
 	messageTextMaxLength: 1040,
-	
+
 	// Defines if the socket server is enabled:
 	socketServerEnabled: false,
 	// Defines the hostname of the socket server used to connect from client side:
@@ -259,6 +259,9 @@ var ajaxChatConfig = {
 	// Defines the port of the socket server:
 	socketServerPort: 1935,
 	// This ID can be used to distinguish between different chat installations using the same socket server:
-	socketServerChatID: 0
+	socketServerChatID: 0,
+
+	// Debug allows console logging or alerts on caught errors - false/0 = no debug, true/1/2 = console log, 2 = alerts
+	debug: false
 
 }

--- a/chat/js/config.js
+++ b/chat/js/config.js
@@ -14,8 +14,12 @@ var ajaxChatConfig = {
 	// The channelName of the channel to enter on login (the default channel is used if set to null):
 	loginChannelName: null,
 
-	// The time in ms between update calls to retrieve new chat messages:
+	// The time in ms between update calls to retrieve new chat messages when active:
 	timerRate: 2000,
+	// The time in ms between update calls to retrieve new chat messages when inactive:
+	inactiveRate: 10000,
+	// The time in seconds after last chat send to become inactive:
+	inactivePeriod: 60,
 
 	// The URL to retrieve the XML chat messages (must at least contain one parameter):
 	ajaxURL: './?ajax=true',

--- a/chat/js/logs.js
+++ b/chat/js/logs.js
@@ -17,6 +17,7 @@
 		if(this.socketServerEnabled) {
 			infos += ',socketRegistrationID';
 		}
+		this.actualRate = this.timerRate;
 		this.updateChat('&getInfos=' + this.encodeText(infos));
 	}
 
@@ -40,9 +41,9 @@
 	}
 
 	ajaxChat.sendMessage = function() {
-		this.getLogs();	
+		this.getLogs();
 	}
-	
+
 	ajaxChat.getLogs = function() {
 		clearTimeout(this.timer);
 		this.clearChatList();
@@ -50,7 +51,7 @@
 		this.logsCommand = null;
 		this.makeRequest(this.ajaxURL,'POST',this.getLogsCommand());
 	}
-	
+
 	ajaxChat.getLogsCommand = function() {
 		if(!this.logsCommand) {
 			if(!this.dom['inputField'].value &&
@@ -83,7 +84,7 @@
 		}
 		return true;
 	}
-	
+
 	ajaxChat.logout = function() {
 		clearTimeout(this.timer);
 		this.makeRequest(this.ajaxURL,'POST','logout=true');
@@ -107,7 +108,7 @@
 		}
 		this.timer = setTimeout('ajaxChat.updateChat(null);', timeout);
 	}
-	
+
 	ajaxChat.socketUpdate = function(data) {
 		if(this.logsMonitorMode) {
 			var xmlDoc = this.loadXML(data);
@@ -125,4 +126,3 @@
 			}
 		}
 	}
-	

--- a/chat/lib/template/loggedIn.html
+++ b/chat/lib/template/loggedIn.html
@@ -28,9 +28,9 @@
 			function toggleContainer(containerID, hideContainerIDs) {
 				if(hideContainerIDs) {
 					for(var i=0; i<hideContainerIDs.length; i++) {
-						ajaxChat.showHide(hideContainerIDs[i], 'none');	
+						ajaxChat.showHide(hideContainerIDs[i], 'none');
 					}
-				}		
+				}
 				ajaxChat.showHide(containerID);
 				if(typeof arguments.callee.styleProperty == 'undefined') {
 					if(typeof isIElt7 != 'undefined') {
@@ -41,10 +41,10 @@
 				}
 				var containerWidth = document.getElementById(containerID).offsetWidth;
 				if(containerWidth) {
-					document.getElementById('chatList').style[arguments.callee.styleProperty] = (containerWidth+28)+'px';	
+					document.getElementById('chatList').style[arguments.callee.styleProperty] = (containerWidth+28)+'px';
 				} else {
 					document.getElementById('chatList').style[arguments.callee.styleProperty] = '20px';
-				}				
+				}
 			}
 
 			function initialize() {
@@ -98,26 +98,26 @@
 			ajaxChatConfig.socketServerHost = decodeURIComponent('[SOCKET_SERVER_HOST/]');
 			ajaxChatConfig.socketServerPort = parseInt('[SOCKET_SERVER_PORT/]');
 			ajaxChatConfig.socketServerChatID = parseInt('[SOCKET_SERVER_CHAT_ID/]');
-		
+
 			ajaxChat.init(ajaxChatConfig, ajaxChatLang, true, true, true, initialize);
 		// ]]>
 	</script>
 </head>
 
 <body>
-	<div id="content">
+	<div id="content" class="chat">
 		<div id="headlineContainer">
 			<h1>[LANG]title[/LANG]</h1>
 		</div>
 		<div id="logoutChannelContainer">
-  			<input type="button" id="logoutButton" value="[LANG]logout[/LANG]" onclick="ajaxChat.logout();"/>
+			<input type="button" id="logoutButton" value="[LANG]logout[/LANG]" onclick="ajaxChat.logout();"/>
 			<label for="channelSelection">[LANG]channel[/LANG]:</label>
 			<select id="channelSelection" onchange="ajaxChat.switchChannel(this.options[this.selectedIndex].value);">[CHANNEL_OPTIONS/]</select>
 			<label for="styleSelection">[LANG]style[/LANG]:</label>
 			<select id="styleSelection" onchange="ajaxChat.setActiveStyleSheet(ajaxChat.getSelectedStyle());">[STYLE_OPTIONS/]</select>
 			<label for="languageSelection">[LANG]language[/LANG]:</label>
 			<select id="languageSelection" onchange="ajaxChat.switchLanguage(this.value);">[LANGUAGE_OPTIONS/]</select>
-  		</div>
+		</div>
 		<div id="statusIconContainer" class="statusContainerOn"></div>
 		<!--[if lt IE 7]>
 			<div></div>
@@ -164,7 +164,7 @@
 					<tr class="rowEven">
 						<td class="desc">[LANG]helpItemDescJoinCreate[/LANG]</td>
 						<td class="code">[LANG]helpItemCodeJoinCreate[/LANG]</td>
-					
+
 					</tr>
 					<tr class="rowOdd">
 						<td class="desc">[LANG]helpItemDescInvite[/LANG]</td>
@@ -174,7 +174,7 @@
 						<td class="desc">[LANG]helpItemDescUninvite[/LANG]</td>
 						<td class="code">[LANG]helpItemCodeUninvite[/LANG]</td>
 					</tr>
-					
+
 					<tr class="rowOdd">
 						<td class="desc">[LANG]helpItemDescLogout[/LANG]</td>
 						<td class="code">[LANG]helpItemCodeLogout[/LANG]</td>
@@ -184,7 +184,7 @@
 						<td class="code">[LANG]helpItemCodePrivateMessage[/LANG]</td>
 					</tr>
 					<tr class="rowOdd">
-					
+
 						<td class="desc">[LANG]helpItemDescQueryOpen[/LANG]</td>
 						<td class="code">[LANG]helpItemCodeQueryOpen[/LANG]</td>
 					</tr>
@@ -193,7 +193,7 @@
 						<td class="code">[LANG]helpItemCodeQueryClose[/LANG]</td>
 					</tr>
 					<tr class="rowOdd">
-						<td class="desc">[LANG]helpItemDescAction[/LANG]</td>				
+						<td class="desc">[LANG]helpItemDescAction[/LANG]</td>
 						<td class="code">[LANG]helpItemCodeAction[/LANG]</td>
 					</tr>
 					<tr class="rowEven">
@@ -203,7 +203,7 @@
 					<tr class="rowOdd">
 						<td class="desc">[LANG]helpItemDescIgnore[/LANG]</td>
 						<td class="code">[LANG]helpItemCodeIgnore[/LANG]</td>
-					
+
 					</tr>
 					<tr class="rowEven">
 						<td class="desc">[LANG]helpItemDescIgnoreList[/LANG]</td>
@@ -213,7 +213,7 @@
 						<td class="desc">[LANG]helpItemDescWhereis[/LANG]</td>
 						<td class="code">[LANG]helpItemCodeWhereis[/LANG]</td>
 					</tr>
-					
+
 					<tr class="rowEven">
 						<td class="desc">[LANG]helpItemDescKick[/LANG]</td>
 						<td class="code">[LANG]helpItemCodeKick[/LANG]</td>
@@ -223,7 +223,7 @@
 						<td class="code">[LANG]helpItemCodeUnban[/LANG]</td>
 					</tr>
 					<tr class="rowEven">
-					
+
 						<td class="desc">[LANG]helpItemDescBans[/LANG]</td>
 						<td class="code">[LANG]helpItemCodeBans[/LANG]</td>
 					</tr>
@@ -233,7 +233,7 @@
 					</tr>
 					<tr class="rowEven">
 						<td class="desc">[LANG]helpItemDescWho[/LANG]</td>
-					
+
 						<td class="code">[LANG]helpItemCodeWho[/LANG]</td>
 					</tr>
 					<tr class="rowOdd">
@@ -243,7 +243,7 @@
 					<tr class="rowEven">
 						<td class="desc">[LANG]helpItemDescRoll[/LANG]</td>
 						<td class="code">[LANG]helpItemCodeRoll[/LANG]</td>
-					
+
 					</tr>
 					<tr class="rowOdd">
 						<td class="desc">[LANG]helpItemDescNick[/LANG]</td>
@@ -382,7 +382,7 @@
 			Please retain the full copyright notice below including the link to blueimp.net.
 			This not only gives respect to the amount of time given freely by the developer
 			but also helps build interest, traffic and use of AJAX Chat.
-			
+
 			Thanks,
 			Sebastian Tschan
 		//-->

--- a/chat/lib/template/logs.html
+++ b/chat/lib/template/logs.html
@@ -24,13 +24,13 @@
 	<script src="js/config.js" type="text/javascript" charset="UTF-8"></script>
 	<script src="js/FABridge.js" type="text/javascript" charset="UTF-8"></script>
 	<script type="text/javascript">
-		// <![CDATA[			
+		// <![CDATA[
 			function toggleContainer(containerID, hideContainerIDs) {
 				if(hideContainerIDs) {
 					for(var i=0; i<hideContainerIDs.length; i++) {
-						ajaxChat.showHide(hideContainerIDs[i], 'none');	
+						ajaxChat.showHide(hideContainerIDs[i], 'none');
 					}
-				}		
+				}
 				ajaxChat.showHide(containerID);
 				if(typeof arguments.callee.styleProperty == 'undefined') {
 					if(typeof isIElt7 != 'undefined') {
@@ -41,10 +41,10 @@
 				}
 				var containerWidth = document.getElementById(containerID).offsetWidth;
 				if(containerWidth) {
-					document.getElementById('chatList').style[arguments.callee.styleProperty] = (containerWidth+28)+'px';	
+					document.getElementById('chatList').style[arguments.callee.styleProperty] = (containerWidth+28)+'px';
 				} else {
 					document.getElementById('chatList').style[arguments.callee.styleProperty] = '20px';
-				}				
+				}
 			}
 
 			function initialize() {
@@ -108,14 +108,14 @@
 			ajaxChatConfig.settings.audio = false;
 			ajaxChatConfig.settings.blink = false;
 			ajaxChatConfig.nonPersistentSettings.push('dateFormat','audio','blink');
-			
+
 			ajaxChat.init(ajaxChatConfig, ajaxChatLang, true, true, true, initialize);
 		// ]]>
 	</script>
 </head>
 
 <body>
-	<div id="content">
+	<div id="content" class="logs">
 		<div id="headlineContainer">
 			<h1>[LANG]logsTitle[/LANG]</h1>
 		</div>
@@ -133,7 +133,8 @@
 			<select id="styleSelection" onchange="ajaxChat.setActiveStyleSheet(ajaxChat.getSelectedStyle());">[STYLE_OPTIONS/]</select>
 			<label for="languageSelection">[LANG]language[/LANG]:</label>
 			<select id="languageSelection" onchange="ajaxChat.switchLanguage(this.value);">[LANGUAGE_OPTIONS/]</select>
-  		</div>
+		</div>
+		<div id="statusIconContainer" class="statusContainerOn"></div>
 		<!--[if lt IE 7]>
 			<div></div>
 		<![endif]-->
@@ -148,10 +149,10 @@
 			<input type="image" src="img/pixel.gif" class="button" id="settingsButton" alt="[LANG]toggleSettings[/LANG]" title="[LANG]toggleSettings[/LANG]" onclick="toggleContainer('settingsContainer');"/>
 			<input type="image" src="img/pixel.gif" class="button" id="audioButton" alt="[LANG]toggleAudio[/LANG]" title="[LANG]toggleAudio[/LANG]" onclick="ajaxChat.toggleSetting('audio', 'audioButton');"/>
 			<input type="image" src="img/pixel.gif" class="button" id="autoScrollButton" alt="[LANG]toggleAutoScroll[/LANG]" title="[LANG]toggleAutoScroll[/LANG]" onclick="ajaxChat.toggleSetting('autoScroll', 'autoScrollButton')"/>
-  		</div>
-	  	<div id="settingsContainer" style="display:none;">
- 			<h3>[LANG]settings[/LANG]</h3>
- 			<div id="settingsList">
+		</div>
+		<div id="settingsContainer" style="display:none;">
+			<h3>[LANG]settings[/LANG]</h3>
+			<div id="settingsList">
 				<table>
 					<tr class="rowOdd">
 						<td><label for="bbCodeSetting">[LANG]settingsBBCode[/LANG]</label></td>
@@ -271,7 +272,7 @@
 			Please retain the full copyright notice below including the link to blueimp.net.
 			This not only gives respect to the amount of time given freely by the developer
 			but also helps build interest, traffic and use of AJAX Chat.
-			
+
 			Thanks,
 			Sebastian Tschan
 		//-->

--- a/chat/lib/template/logs.html
+++ b/chat/lib/template/logs.html
@@ -48,7 +48,6 @@
 			}
 
 			function initialize() {
-				toggleContainer('settingsContainer');
 				ajaxChat.updateButton('audio', 'audioButton');
 				ajaxChat.updateButton('autoScroll', 'autoScrollButton');
 				document.getElementById('bbCodeSetting').checked = ajaxChat.getSetting('bbCode');


### PR DESCRIPTION
... if user is not actively typing messages. So e.g. normal ajax rate is every 2s, but if user has not sent anything for say 60 seconds, then the ajax rate slows to e.g. every 10s until they send something again. This will assist with scalability by reducing the number of ajax calls being made.

Also:
1. Add debugging setting / console.log messages / alerts.
2. Correct the retry timeout calculation which looked incorrect.
3. Add a status blinking icon to the logs screen
4. Add classes on the #content div so you can distinguish between chat and log views in custom css.
5. Using 4., avoid need to show log settings by setting chatbox right margin on logs.
