### PR TITLE
small changes for compatibility with SMF 2.0.x

### DIFF
--- a/chat/lib/class/CustomAJAXChat.php
+++ b/chat/lib/class/CustomAJAXChat.php
@@ -21,10 +21,10 @@ class CustomAJAXChat extends AJAXChat {
 
 		// SMF uses a db prefix so we need to add it to every ajax table.
 		$tables = array (
-			'online' => $db_prefix .'ajaxchat_online',
-			'messages' => $db_prefix .'ajaxchat_messages',
-			'bans' => $db_prefix .'ajaxchat_bans',
-			'invitations' => $db_prefix .'ajaxchat_invitations',
+			'online' => $db_prefix .'ajax_chat_online',
+			'messages' => $db_prefix .'ajax_chat_messages',
+			'bans' => $db_prefix .'ajax_chat_bans',
+			'invitations' => $db_prefix .'ajax_chat_invitations',
 		);
 
 		$this->setConfig('dbTableNames', false, $tables);


### PR DESCRIPTION
This PR adds minor changes to make ajaxChat 0.8.7 compatible with SMF 2.0.x
- SMF uses a unique prefix on all its tables so we need to add it to our ajax chat tables as well.
- Since we already added the prefix, the check on AJAXChat::getDataBaseTable() becomes obsolete so re-write the method to skip it.
