### PR TITLE
Login when password(not userName) is available. Enables the possibility ...

### DIFF
--- a/chat/lib/class/AJAXChat.php
+++ b/chat/lib/class/AJAXChat.php
@@ -143,7 +143,7 @@ class AJAXChat {
 			// Login if auto-login enabled or a login, userName or shoutbox parameter is given:
 			$this->getConfig('forceAutoLogin') ||
 			$this->getRequestVar('login') ||
-			$this->getRequestVar('userName') ||
+			$this->getRequestVar('password') ||
 			$this->getRequestVar('shoutbox')
 			) {
 			$this->login();


### PR DESCRIPTION
...to login using other user identifiers, e.g user-id

Currently I'm integrating AJAX-Chat into a site via an iframe. Login is done using the `userID` and `password`. Would need to supply an additional parameter e.g `login=true` without this change.
