### PR TITLE
Case-insensitive online user list

### DIFF
--- a/chat/lib/class/AJAXChat.php
+++ b/chat/lib/class/AJAXChat.php
@@ -2389,7 +2389,7 @@ class AJAXChat {
 					FROM
 						'.$this->getDataBaseTable('online').'
 					ORDER BY
-						userName;';
+						LOWER(userName);';
 			
 			// Create a new SQL query:
 			$result = $this->db->sqlQuery($sql);


### PR DESCRIPTION
This modification was originally posted to Google Groups by Ingrid but I think it would be of benefit to AJAX-Chat (it is so simple).

There are some alternatives to this method, like changing the collation of the userName field in ajaxchat_online from "utf_bin" to "utf8_general_ci".

With multiple language translations, I'm not sure which of these methods would be best.
