### PR TITLE
Fix for dice roller

### DIFF
--- a/chat/lib/class/AJAXChat.php
+++ b/chat/lib/class/AJAXChat.php
@@ -1613,9 +1613,6 @@ class AJAXChat {
 	}
 	
 	function rollDice($sides) {
-		// seed with microseconds since last "whole" second:
-		mt_srand((double)microtime()*1000000);
-		
 		return mt_rand(1, $sides);
 	}
 	


### PR DESCRIPTION
Removed mt_srand and seed; seeding is performed automatically in PHP5+.

This fixes #167 (Credit goes to @jpreston86)
