### PR TITLE
Prevent malicious user from forcing Logout

### DIFF
--- a/chat/js/chat.js
+++ b/chat/js/chat.js
@@ -2660,6 +2660,8 @@ var ajaxChat = {
 	},
 
 	replaceBBCodeImage: function(url) {
+		// prevent embeding chat logout URL in images by stripping it from url
+		url = url.replace("?logout=true", "");
 		var regExpUrl, maxWidth, maxHeight, link;
 		if(this.settings['bbCodeImages']) {
 			regExpUrl = new RegExp(


### PR DESCRIPTION
Due to the fact that AjaxChat does not use tokens to verify logouts were
authorized by a chat user, a CSRF vulnerability was discovered that
permitted a malicious chatter to post the chat's logout URL inside the
img tags of a chat room, forcing all users, including moderators and
administrators to log out unless they had initially disabled image parsing in settings (enabled by default). The issue also prevents further users to log in for
a period of time due to the log inside the chat, until the image
disappears from the log.

This simple modification simple checks the URL inside the img code,
checks for ?logout=true (part of the URL in ajax chat for logging out)
and strips it. Ugly hack, but does the job. If one wanted to make it
more complex they could also write it to check the domain and path of
the chat, but doing so would allow someone to logout a user in one chat
room who is logged in at the same time in another.