### PR TITLE
Fix KeyPress/KeyDown event in shoutbox and logs

### DIFF
--- a/chat/lib/template/logs.html
+++ b/chat/lib/template/logs.html
@@ -118,7 +118,7 @@
 		<![endif]-->
 		<div id="chatList"></div>
 		<div id="inputFieldContainer">
-			<textarea id="inputField" rows="1" cols="50" title="[LANG]inputLineBreak[/LANG]" onkeypress="ajaxChat.handleInputFieldKeyPress(event);"></textarea>
+			<textarea id="inputField" rows="1" cols="50" title="[LANG]inputLineBreak[/LANG]" onkeypress="ajaxChat.handleInputFieldKeyDown(event);"></textarea>
 		</div>
 		<div id="submitButtonContainer">
 			<input type="button" id="submitButton" value="[LANG]logsSearch[/LANG]" onclick="ajaxChat.sendMessage();"/>

--- a/chat/lib/template/shoutbox.html
+++ b/chat/lib/template/shoutbox.html
@@ -7,7 +7,7 @@
 	<script src="[AJAX_CHAT_URL/]js/FABridge.js" type="text/javascript" charset="UTF-8"></script>
 	<div id="ajaxChatChatList"></div>
 	<div id="ajaxChatInputFieldContainer" class="[CLASS_WRITEABLE/]">
-		<input id="ajaxChatInputField" type="text" maxlength="[MESSAGE_TEXT_MAX_LENGTH/]" onkeypress="ajaxChat.handleInputFieldKeyPress(event);"/>
+		<input id="ajaxChatInputField" type="text" maxlength="[MESSAGE_TEXT_MAX_LENGTH/]" onkeypress="ajaxChat.handleInputFieldKeyDown(event);"/>
 	</div>
 	<script type="text/javascript">
 		// <![CDATA[


### PR DESCRIPTION
With current master it's not possible to send a message directly from shoutbox due to incomplete event refactorization/rename. This PR fixes it. And also #215